### PR TITLE
[Add] Stylus package support

### DIFF
--- a/comment-basic.sublime-snippet
+++ b/comment-basic.sublime-snippet
@@ -3,6 +3,6 @@
 /* ${1:comment} */
 ]]></content>
 	<tabTrigger>c-basic</tabTrigger>
-	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.php</scope>
+	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.stylus, source.php</scope>
 	<description>Basic Comment</description>
 </snippet>

--- a/comment-long.sublime-snippet
+++ b/comment-long.sublime-snippet
@@ -5,6 +5,6 @@
  */
 ]]></content>
 	<tabTrigger>c-long</tabTrigger>
-	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.php</scope>
+	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.stylus, source.php</scope>
 	<description>Long Comment</description>
 </snippet>

--- a/comment-multi.sublime-snippet
+++ b/comment-multi.sublime-snippet
@@ -18,6 +18,6 @@
  */
 ]]></content>
 	<tabTrigger>c-multi</tabTrigger>
-	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.php</scope>
+	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.stylus, source.php</scope>
 	<description>Multiple Comment with TODO</description>
 </snippet>

--- a/comment-section.sublime-snippet
+++ b/comment-section.sublime-snippet
@@ -5,6 +5,6 @@
    ========================================================================== */
 ]]></content>
 	<tabTrigger>c-section</tabTrigger>
-	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.php</scope>
+	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.stylus, source.php</scope>
 	<description>Section Comment</description>
 </snippet>

--- a/comment-subsection.sublime-snippet
+++ b/comment-subsection.sublime-snippet
@@ -4,6 +4,6 @@
    ========================================================================== */
 ]]></content>
 	<tabTrigger>c-subsection</tabTrigger>
-	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.php</scope>
+	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.stylus, source.php</scope>
 	<description>Sub-section Comment</description>
 </snippet>

--- a/comment-summary.sublime-snippet
+++ b/comment-summary.sublime-snippet
@@ -27,6 +27,6 @@
    ========================================================================== */
 ]]></content>
 	<tabTrigger>c-summary</tabTrigger>
-	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.php</scope>
+	<scope>source.css, source.scss, source.sass, source.less, source.styl, source.stylus, source.php</scope>
 	<description>Summary Comment</description>
 </snippet>


### PR DESCRIPTION
I use [**Stylus**](https://github.com/billymoon/Stylus) Sublime Text package, where **[`source.stylus`](https://github.com/billymoon/Stylus/blob/master/Stylus.tmLanguage#L8)** scope, not `source.styl`. It would be nice, if your package will support Stylus package too.

Thanks.